### PR TITLE
解决在屏幕添加字符失败时候发生的崩溃问题

### DIFF
--- a/NEMbox/ui.py
+++ b/NEMbox/ui.py
@@ -85,8 +85,10 @@ class Ui(object):
         if len(args) == 1:
             self.screen.addstr(args[0])
         else:
-            self.screen.addstr(args[0], args[1], args[2].encode('utf-8'), *args[3:])
-
+            try:
+                self.screen.addstr(args[0], args[1], args[2].encode('utf-8'), *args[3:])
+            except Exception as e:
+                log.error(e)
     def build_playinfo(self,
                        song_name,
                        artist,


### PR DESCRIPTION
rehl7.4，python3.7，安装之后添加字符串出错之后，报self.screen.addstr(]出错，页面打印出出错信息，并且无法退出，只能关终端。添加try/except捕捉之后问题消失。